### PR TITLE
Project: Steno.fm the search engine for podcasts with Member Theo Pak

### DIFF
--- a/projects/stenofm/members.txt
+++ b/projects/stenofm/members.txt
@@ -1,0 +1,2 @@
+- Theo Pak, theopak@gmail.com 
+


### PR DESCRIPTION
Adds a new RCOS project and notes myself as a member.

This RCOS project is called [Steno.fm](http://steno.fm) and it lives at http://github.com/theopak/steno. 
